### PR TITLE
Fix timezone when creating habits

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -4,7 +4,6 @@ import { createServerSupabaseClient } from "../lib/supabase/server";
 import { redirect } from "next/navigation";
 import prisma from "../prisma/db";
 import { revalidatePath } from "next/cache";
-import { startOfToday } from "date-fns";
 
 export async function logout() {
   const supabase = await createServerSupabaseClient();
@@ -84,7 +83,8 @@ export async function createHabit(_: unknown, formData: FormData) {
     await prisma.activity.create({
       data: {
         habitId: newHabit.id,
-        date: startOfToday(), //
+        // use UTC date to match completion logic
+        date: getTodayUTC(),
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- use UTC helper when saving the first activity for a habit

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f09835508330a173dc6b3c2e60e6