### PR TITLE
Add Vitest tests for stats utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:studio": "prisma studio --schema=prisma/schema.prisma",
     "db:generate": "prisma generate --schema=prisma/schema.prisma",
     "docker:up": "docker-compose up -d",
-    "docker:down": "docker-compose down"
+    "docker:down": "docker-compose down",
+    "test": "vitest"
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",
@@ -60,7 +61,9 @@
     "prisma": "^6.5.0",
     "tailwindcss": "^4",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^1.5.0",
+    "vite-tsconfig-paths": "^4.3.2"
   },
   "prisma": {
     "schema": "prisma/schema.prisma"

--- a/tests/stats-utils.test.ts
+++ b/tests/stats-utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { calculateStreak, getCompletionRate, getHabitStats } from '../lib/stats-utils';
+import { Habit, Activity } from '../types/habit';
+
+describe('calculateStreak', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-01-10'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 for no activities', () => {
+    expect(calculateStreak([])).toBe(0);
+  });
+
+  it('counts consecutive days', () => {
+    const activities: Activity[] = [
+      { id: '1', date: new Date('2023-01-10'), habitId: 'h1' },
+      { id: '2', date: new Date('2023-01-09'), habitId: 'h1' },
+      { id: '3', date: new Date('2023-01-08'), habitId: 'h1' },
+      { id: '4', date: new Date('2023-01-06'), habitId: 'h1' },
+    ];
+    expect(calculateStreak(activities)).toBe(3);
+  });
+
+  it('returns 0 when today is missing', () => {
+    const activities: Activity[] = [
+      { id: '1', date: new Date('2023-01-09'), habitId: 'h1' },
+    ];
+    expect(calculateStreak(activities)).toBe(0);
+  });
+});
+
+describe('getCompletionRate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-01-10'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calculates daily rate', () => {
+    const activities: Activity[] = [
+      { id: '1', date: new Date('2023-01-01'), habitId: 'h1' },
+      { id: '2', date: new Date('2023-01-03'), habitId: 'h1' },
+      { id: '3', date: new Date('2023-01-05'), habitId: 'h1' },
+      { id: '4', date: new Date('2023-01-10'), habitId: 'h1' },
+    ];
+    expect(getCompletionRate(activities, 'daily', new Date('2023-01-01'))).toBe(40);
+  });
+
+  it('calculates weekly rate', () => {
+    const activities: Activity[] = [
+      { id: '1', date: new Date('2023-01-03'), habitId: 'h1' },
+    ];
+    expect(getCompletionRate(activities, 'weekly', new Date('2023-01-01'))).toBe(50);
+  });
+
+  it('calculates monthly rate', () => {
+    const activities: Activity[] = [
+      { id: '1', date: new Date('2023-01-03'), habitId: 'h1' },
+    ];
+    expect(getCompletionRate(activities, 'monthly', new Date('2023-01-01'))).toBe(100);
+  });
+});
+
+describe('getHabitStats', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-01-10'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns combined statistics', () => {
+    const habit: Habit = {
+      id: 'h1',
+      title: 'Test',
+      description: null,
+      frequency: 'daily',
+      createdAt: new Date('2023-01-01'),
+      activities: [
+        { id: '1', date: new Date('2023-01-10'), habitId: 'h1' },
+        { id: '2', date: new Date('2023-01-09'), habitId: 'h1' },
+      ],
+    };
+    expect(getHabitStats(habit)).toEqual({
+      completionRate: 20,
+      currentStreak: 2,
+      totalCheckIns: 2,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vitest configuration and npm test script
- add unit tests for stats helpers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f35da2e883308f25145b34ffbcaa