### PR TITLE
feat: Add analytics page

### DIFF
--- a/app/(dashboard)/analytics/page.tsx
+++ b/app/(dashboard)/analytics/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Habit } from "@/types/habit";
+import { getAnalyticsStats } from "@/lib/analytics-utils";
+import { Spinner } from "@/components/ui/spinner";
+import { Card } from "@/components/ui/card";
+import {
+  Flame,
+  LineChart,
+  Target,
+  TrendingUp,
+  ListChecks,
+  Trophy,
+} from "lucide-react";
+
+export default function AnalyticsPage() {
+  const [habits, setHabits] = useState<Habit[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchHabits = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/habits");
+        if (!res.ok) throw new Error("Failed to fetch habits");
+        const data = await res.json();
+        setHabits(data);
+      } catch (err) {
+        console.error(err);
+        setError("Unable to load analytics.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchHabits();
+  }, []);
+
+  const stats = getAnalyticsStats(habits);
+
+  return (
+    <main className="max-w-2xl w-full md:px-0 px-4 space-y-4">
+      <h1 className="text-3xl font-bold mb-4">Analytics</h1>
+      {loading ? (
+        <Spinner size="large" />
+      ) : error ? (
+        <div className="text-center text-red-500">{error}</div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <AnalyticsCard
+            title="Total Habits"
+            value={stats.totalHabits}
+            icon={TrendingUp}
+          />
+          <AnalyticsCard
+            title="Total Check-ins"
+            value={stats.totalCheckIns}
+            icon={ListChecks}
+          />
+          <AnalyticsCard
+            title="Overall Completion"
+            value={`${stats.overallCompletionRate}%`}
+            icon={Target}
+          />
+          <AnalyticsCard
+            title="Longest Streak"
+            value={stats.longestStreak}
+            icon={Flame}
+          />
+          {stats.bestHabit && (
+            <AnalyticsCard
+              title={`Best Habit: ${stats.bestHabit.title}`}
+              value={`${stats.bestHabit.completionRate}%`}
+              icon={Trophy}
+            />
+          )}
+          <AnalyticsCard
+            title="Check-ins This Week"
+            value={stats.checkInsThisWeek}
+            icon={LineChart}
+          />
+        </div>
+      )}
+    </main>
+  );
+}
+
+function AnalyticsCard({
+  title,
+  value,
+  icon: Icon,
+}: {
+  title: string;
+  value: React.ReactNode;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}) {
+  return (
+    <Card className="p-4 flex items-center gap-4">
+      <Icon className="w-6 h-6 text-primary" />
+      <div className="flex flex-col">
+        <span className="text-sm text-muted-foreground">{title}</span>
+        <span className="text-xl font-semibold">{value}</span>
+      </div>
+    </Card>
+  );
+}

--- a/components/desktop-navbar.tsx
+++ b/components/desktop-navbar.tsx
@@ -47,7 +47,12 @@ export function DesktopNavbar() {
       disabled: false,
     },
     { href: "/calendar", label: "Calendar", icon: Calendar, disabled: true },
-    { href: "/analytics", label: "Analytics", icon: BarChart2, disabled: true },
+    {
+      href: ROUTES.APP.ANALYTICS,
+      label: "Analytics",
+      icon: BarChart2,
+      disabled: false,
+    },
   ];
 
   const userInitials = user?.email

--- a/components/mobile-navbar.tsx
+++ b/components/mobile-navbar.tsx
@@ -34,7 +34,12 @@ export function MobileNavbar() {
       disabled: false,
     },
     { href: "/calendar", label: "Calendar", icon: Calendar, disabled: true },
-    { href: "/analytics", label: "Analytics", icon: BarChart2, disabled: true },
+    {
+      href: ROUTES.APP.ANALYTICS,
+      label: "Analytics",
+      icon: BarChart2,
+      disabled: false,
+    },
   ];
 
   return (

--- a/lib/analytics-utils.ts
+++ b/lib/analytics-utils.ts
@@ -1,0 +1,67 @@
+import { Habit } from "@/types/habit";
+import { getHabitStats, calculateStreak } from "./stats-utils";
+import { startOfToday, subDays, isWithinInterval } from "date-fns";
+
+export interface AnalyticsStats {
+  totalHabits: number;
+  totalCheckIns: number;
+  overallCompletionRate: number;
+  longestStreak: number;
+  checkInsThisWeek: number;
+  bestHabit?: {
+    id: string;
+    title: string;
+    completionRate: number;
+  };
+}
+
+export function getAnalyticsStats(habits: Habit[]): AnalyticsStats {
+  const totalHabits = habits.length;
+
+  const totalCheckIns = habits.reduce(
+    (sum, habit) => sum + habit.activities.length,
+    0,
+  );
+
+  const overallCompletionRate = totalHabits
+    ? Math.round(
+        habits.reduce(
+          (sum, habit) => sum + getHabitStats(habit).completionRate,
+          0,
+        ) / totalHabits,
+      )
+    : 0;
+
+  const longestStreak = habits.reduce((max, habit) => {
+    const streak = calculateStreak(habit.activities);
+    return streak > max ? streak : max;
+  }, 0);
+
+  let bestHabit: AnalyticsStats["bestHabit"];
+  for (const habit of habits) {
+    const rate = getHabitStats(habit).completionRate;
+    if (!bestHabit || rate > bestHabit.completionRate) {
+      bestHabit = { id: habit.id, title: habit.title, completionRate: rate };
+    }
+  }
+
+  const today = startOfToday();
+  const weekAgo = subDays(today, 6);
+  const checkInsThisWeek = habits.reduce((count, habit) => {
+    return (
+      count +
+      habit.activities.filter((a) =>
+        isWithinInterval(new Date(a.date), { start: weekAgo, end: today }),
+      ).length
+    );
+  }, 0);
+
+  return {
+    totalHabits,
+    totalCheckIns,
+    overallCompletionRate,
+    longestStreak,
+    checkInsThisWeek,
+    bestHabit,
+  };
+}

--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
     DASHBOARD: "/dashboard",
     SETTINGS: "/settings",
     NEW_HABIT: "/habits/new",
+    ANALYTICS: "/analytics",
   },
   LANDING: {
     HOME: "/",

--- a/tests/analytics-utils.test.ts
+++ b/tests/analytics-utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getAnalyticsStats } from "../lib/analytics-utils";
+import { Habit } from "../types/habit";
+
+const baseHabit = {
+  description: null,
+  frequency: "daily",
+  createdAt: new Date("2023-01-01"),
+};
+
+describe("getAnalyticsStats", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2023-01-10"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("computes aggregated statistics", () => {
+    const habits: Habit[] = [
+      {
+        ...baseHabit,
+        id: "h1",
+        title: "H1",
+        activities: [
+          { id: "a1", habitId: "h1", date: new Date("2023-01-09") },
+          { id: "a2", habitId: "h1", date: new Date("2023-01-10") },
+        ],
+      },
+      {
+        ...baseHabit,
+        id: "h2",
+        title: "H2",
+        activities: [{ id: "b1", habitId: "h2", date: new Date("2023-01-08") }],
+      },
+    ];
+
+    const stats = getAnalyticsStats(habits);
+
+    expect(stats.totalHabits).toBe(2);
+    expect(stats.totalCheckIns).toBe(3);
+    expect(stats.longestStreak).toBe(2);
+    expect(stats.checkInsThisWeek).toBe(3);
+    expect(stats.overallCompletionRate).toBe(15);
+    expect(stats.bestHabit?.id).toBe("h1");
+  });
+});


### PR DESCRIPTION
## Summary
- add analytics utilities for aggregated stats
- expose analytics route in constants
- add new Analytics page with stats cards
- update navbars to link Analytics page
- test analytics utilities
- enhance analytics

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847f744a0c88330a0f0891d96c5046d