### PR TITLE
Improve navbar implementation

### DIFF
--- a/components/desktop-navbar.tsx
+++ b/components/desktop-navbar.tsx
@@ -2,14 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  Home,
-  PlusCircle,
-  BarChart2,
-  Calendar,
-  Settings,
-  LogOut,
-} from "lucide-react";
+import { Settings, LogOut } from "lucide-react";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -17,6 +10,7 @@ import {
 } from "./ui/navigation-menu";
 import { cn } from "../lib/utils";
 import { ROUTES } from "@/lib/constants/routes";
+import { APP_NAV_ITEMS } from "@/lib/constants/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import {
   DropdownMenu,
@@ -33,105 +27,85 @@ export function DesktopNavbar() {
   const pathname = usePathname();
   const { user } = useAuthStore();
 
-  const primaryNav = [
-    {
-      href: ROUTES.APP.DASHBOARD,
-      label: "Overview",
-      icon: Home,
-      disabled: false,
-    },
-    {
-      href: ROUTES.APP.NEW_HABIT,
-      label: "New Habit",
-      icon: PlusCircle,
-      disabled: false,
-    },
-    { href: "/calendar", label: "Calendar", icon: Calendar, disabled: true },
-    {
-      href: ROUTES.APP.ANALYTICS,
-      label: "Analytics",
-      icon: BarChart2,
-      disabled: false,
-    },
-  ];
-
   const userInitials = user?.email
     ? user.email.substring(0, 2).toUpperCase()
     : "U";
 
   return (
-    <nav className="hidden md:flex fixed justify-between w-full px-6 py-4 border-b h-16 border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-sm z-50">
-      <div className="flex items-center gap-2">
-        <Link
-          href={ROUTES.APP.DASHBOARD}
-          className="font-semibold text-lg mr-8"
-        >
-          Habit Tracker
-        </Link>
+    <header className="hidden md:block fixed top-0 inset-x-0 z-50 border-b border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-sm">
+      <div className="flex h-16 items-center justify-between px-6">
+        <div className="flex items-center gap-2">
+          <Link
+            href={ROUTES.APP.DASHBOARD}
+            className="font-semibold text-lg mr-8"
+          >
+            Habit Tracker
+          </Link>
 
-        <NavigationMenu>
-          <NavigationMenuList className="gap-2">
-            {primaryNav.map(({ href, label, icon: Icon, disabled }) => (
-              <NavigationMenuItem key={href}>
-                {disabled ? (
-                  <div
-                    className={cn(
-                      "flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md cursor-not-allowed",
-                      "text-gray-400 dark:text-zinc-600"
-                    )}
-                  >
-                    <Icon className="w-4 h-4" />
-                    {label}
-                  </div>
-                ) : (
-                  <Link
-                    href={href}
-                    className={cn(
-                      "flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors rounded-md",
-                      "text-gray-600 dark:text-zinc-400 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800",
-                      pathname === href &&
-                        "text-black dark:text-white bg-gray-100 dark:bg-zinc-800"
-                    )}
-                  >
-                    <Icon className="w-4 h-4" />
-                    {label}
-                  </Link>
-                )}
-              </NavigationMenuItem>
-            ))}
-          </NavigationMenuList>
-        </NavigationMenu>
+          <NavigationMenu>
+            <NavigationMenuList className="gap-2">
+              {APP_NAV_ITEMS.map(({ href, label, icon: Icon, disabled }) => (
+                <NavigationMenuItem key={href}>
+                  {disabled ? (
+                    <div
+                      className={cn(
+                        "flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md cursor-not-allowed",
+                        "text-gray-400 dark:text-zinc-600",
+                      )}
+                    >
+                      <Icon className="w-4 h-4" />
+                      {label}
+                    </div>
+                  ) : (
+                    <Link
+                      href={href}
+                      className={cn(
+                        "flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors rounded-md",
+                        "text-gray-600 dark:text-zinc-400 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800",
+                        pathname === href &&
+                          "text-black dark:text-white bg-gray-100 dark:bg-zinc-800",
+                      )}
+                    >
+                      <Icon className="w-4 h-4" />
+                      {label}
+                    </Link>
+                  )}
+                </NavigationMenuItem>
+              ))}
+            </NavigationMenuList>
+          </NavigationMenu>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <ColorModeSwitcher />
+
+          <DropdownMenu>
+            <DropdownMenuTrigger className="focus:outline-none">
+              <Avatar className="h-8 w-8">
+                <AvatarImage src={user?.user_metadata?.avatar_url} />
+                <AvatarFallback>{userInitials}</AvatarFallback>
+              </Avatar>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>My Account</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>
+                <Link
+                  href={ROUTES.APP.SETTINGS}
+                  className="flex items-center gap-2 w-full"
+                >
+                  <Settings className="w-4 h-4" />
+                  Settings
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-red-600 dark:text-red-400">
+                <LogOut className="w-4 h-4" />
+                Sign out
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
-
-      <div className="flex items-center gap-4">
-        <ColorModeSwitcher />
-
-        <DropdownMenu>
-          <DropdownMenuTrigger className="focus:outline-none">
-            <Avatar className="h-8 w-8">
-              <AvatarImage src={user?.user_metadata?.avatar_url} />
-              <AvatarFallback>{userInitials}</AvatarFallback>
-            </Avatar>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel>My Account</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem>
-              <Link
-                href={ROUTES.APP.SETTINGS}
-                className="flex items-center gap-2 w-full"
-              >
-                <Settings className="w-4 h-4" />
-                Settings
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem className="text-red-600 dark:text-red-400">
-              <LogOut className="w-4 h-4" />
-              Sign out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </nav>
+    </header>
   );
 }

--- a/components/mobile-navbar.tsx
+++ b/components/mobile-navbar.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, PlusCircle, BarChart2, Calendar, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import { cn } from "../lib/utils";
 import { ROUTES } from "@/lib/constants/routes";
+import { APP_NAV_ITEMS } from "@/lib/constants/navigation";
 import {
   Sheet,
   SheetContent,
@@ -20,59 +21,38 @@ export function MobileNavbar() {
   const pathname = usePathname();
   const { user } = useAuthStore();
 
-  const primaryNav = [
-    {
-      href: ROUTES.APP.DASHBOARD,
-      label: "Overview",
-      icon: Home,
-      disabled: false,
-    },
-    {
-      href: ROUTES.APP.NEW_HABIT,
-      label: "New Habit",
-      icon: PlusCircle,
-      disabled: false,
-    },
-    { href: "/calendar", label: "Calendar", icon: Calendar, disabled: true },
-    {
-      href: ROUTES.APP.ANALYTICS,
-      label: "Analytics",
-      icon: BarChart2,
-      disabled: false,
-    },
-  ];
-
   return (
     <>
       {/* Bottom Navigation */}
       <nav className="fixed bottom-0 z-50 w-full bg-white dark:bg-zinc-900 border-t border-gray-200 dark:border-zinc-800 shadow-sm md:hidden">
         <div className="flex justify-around items-center h-16">
-          {primaryNav.slice(0, 4).map(({ href, label, icon: Icon, disabled }) =>
-            disabled ? (
-              <div
-                key={href}
-                className={cn(
-                  "flex flex-col items-center justify-center flex-1 h-full cursor-not-allowed",
-                  "text-gray-300 dark:text-zinc-700"
-                )}
-              >
-                <Icon className="h-5 w-5 mb-1" />
-                <span className="text-xs font-medium">{label}</span>
-              </div>
-            ) : (
-              <Link
-                key={href}
-                href={href}
-                className={cn(
-                  "flex flex-col items-center justify-center flex-1 h-full transition-colors",
-                  "text-gray-500 dark:text-zinc-400 hover:text-black dark:hover:text-white",
-                  pathname === href && "text-black dark:text-white"
-                )}
-              >
-                <Icon className="h-5 w-5 mb-1" />
-                <span className="text-xs font-medium">{label}</span>
-              </Link>
-            )
+          {APP_NAV_ITEMS.slice(0, 4).map(
+            ({ href, label, icon: Icon, disabled }) =>
+              disabled ? (
+                <div
+                  key={href}
+                  className={cn(
+                    "flex flex-col items-center justify-center flex-1 h-full cursor-not-allowed",
+                    "text-gray-300 dark:text-zinc-700",
+                  )}
+                >
+                  <Icon className="h-5 w-5 mb-1" />
+                  <span className="text-xs font-medium">{label}</span>
+                </div>
+              ) : (
+                <Link
+                  key={href}
+                  href={href}
+                  className={cn(
+                    "flex flex-col items-center justify-center flex-1 h-full transition-colors",
+                    "text-gray-500 dark:text-zinc-400 hover:text-black dark:hover:text-white",
+                    pathname === href && "text-black dark:text-white",
+                  )}
+                >
+                  <Icon className="h-5 w-5 mb-1" />
+                  <span className="text-xs font-medium">{label}</span>
+                </Link>
+              ),
           )}
         </div>
       </nav>
@@ -100,13 +80,13 @@ export function MobileNavbar() {
               <ColorModeSwitcher />
             </div>
             <div className="space-y-1">
-              {primaryNav.map(({ href, label, icon: Icon, disabled }) =>
+              {APP_NAV_ITEMS.map(({ href, label, icon: Icon, disabled }) =>
                 disabled ? (
                   <div
                     key={href}
                     className={cn(
                       "flex items-center gap-2 w-full p-2 text-sm font-medium rounded-md cursor-not-allowed",
-                      "text-gray-400 dark:text-zinc-600"
+                      "text-gray-400 dark:text-zinc-600",
                     )}
                   >
                     <Icon className="h-4 w-4" />
@@ -120,13 +100,13 @@ export function MobileNavbar() {
                       "flex items-center gap-2 w-full p-2 text-sm font-medium rounded-md transition-colors",
                       "text-gray-600 dark:text-zinc-400 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800",
                       pathname === href &&
-                        "text-black dark:text-white bg-gray-100 dark:bg-zinc-800"
+                        "text-black dark:text-white bg-gray-100 dark:bg-zinc-800",
                     )}
                   >
                     <Icon className="h-4 w-4" />
                     {label}
                   </Link>
-                )
+                ),
               )}
             </div>
             <Button variant="destructive" className="w-full mt-8">

--- a/lib/constants/navigation.ts
+++ b/lib/constants/navigation.ts
@@ -1,0 +1,39 @@
+import {
+  Home,
+  PlusCircle,
+  Calendar,
+  BarChart2,
+  LucideIcon,
+} from "lucide-react";
+import { ROUTES } from "./routes";
+
+export type AppNavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  disabled?: boolean;
+};
+
+export const APP_NAV_ITEMS: AppNavItem[] = [
+  {
+    href: ROUTES.APP.DASHBOARD,
+    label: "Overview",
+    icon: Home,
+  },
+  {
+    href: ROUTES.APP.NEW_HABIT,
+    label: "New Habit",
+    icon: PlusCircle,
+  },
+  {
+    href: "/calendar",
+    label: "Calendar",
+    icon: Calendar,
+    disabled: true,
+  },
+  {
+    href: ROUTES.APP.ANALYTICS,
+    label: "Analytics",
+    icon: BarChart2,
+  },
+];


### PR DESCRIPTION
## Summary
- add `APP_NAV_ITEMS` constants to centralize navigation links
- refactor desktop and mobile navbars to use shared config
- adjust desktop navbar semantics

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b03a9b06483309e95397c805e1df1