### PR TITLE
Improve analytics page

### DIFF
--- a/app/(dashboard)/analytics/page.tsx
+++ b/app/(dashboard)/analytics/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Habit } from "@/types/habit";
 import { getAnalyticsStats } from "@/lib/analytics-utils";
 import { Spinner } from "@/components/ui/spinner";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ActivityCalendar } from "react-activity-calendar";
+import { useTheme } from "next-themes";
 import {
   Flame,
   LineChart,
@@ -18,37 +22,54 @@ export default function AnalyticsPage() {
   const [habits, setHabits] = useState<Habit[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { resolvedTheme } = useTheme();
+
+  const fetchHabits = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/habits");
+      if (!res.ok) throw new Error("Failed to fetch habits");
+      const data = await res.json();
+      setHabits(data);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to load analytics.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchHabits = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch("/api/habits");
-        if (!res.ok) throw new Error("Failed to fetch habits");
-        const data = await res.json();
-        setHabits(data);
-      } catch (err) {
-        console.error(err);
-        setError("Unable to load analytics.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchHabits();
   }, []);
 
   const stats = getAnalyticsStats(habits);
+  const calendarData = mapHabitsToCalendarData(habits);
 
   return (
     <main className="max-w-2xl w-full md:px-0 px-4 space-y-4">
-      <h1 className="text-3xl font-bold mb-4">Analytics</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-3xl font-bold">Analytics</h1>
+        <Button variant="outline" size="sm" onClick={fetchHabits}>
+          Refresh
+        </Button>
+      </div>
       {loading ? (
         <Spinner size="large" />
       ) : error ? (
         <div className="text-center text-red-500">{error}</div>
+      ) : habits.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-muted-foreground mb-4">
+            Add habits to see your analytics
+          </p>
+          <Link href="/habits/new">
+            <Button>Add Your First Habit</Button>
+          </Link>
+        </div>
       ) : (
+        <>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <AnalyticsCard
             title="Total Habits"
@@ -70,6 +91,11 @@ export default function AnalyticsPage() {
             value={stats.longestStreak}
             icon={Flame}
           />
+          <AnalyticsCard
+            title="Current Streak"
+            value={stats.globalStreak}
+            icon={Flame}
+          />
           {stats.bestHabit && (
             <AnalyticsCard
               title={`Best Habit: ${stats.bestHabit.title}`}
@@ -83,6 +109,27 @@ export default function AnalyticsPage() {
             icon={LineChart}
           />
         </div>
+        <Card className="p-4">
+          <ActivityCalendar
+            data={calendarData}
+            colorScheme={
+              resolvedTheme === "light" || resolvedTheme === "dark"
+                ? resolvedTheme
+                : undefined
+            }
+            theme={{
+              light: ["#e0e0e0", "#a3d8a3", "#78c78f", "#4dbb7f", "#26a65b"],
+              dark: [
+                "hsl(0, 0%, 22%)",
+                "#4dbb7f",
+                "#78c78f",
+                "#a3d8a3",
+                "#e0e0e0",
+              ],
+            }}
+          />
+        </Card>
+        </>
       )}
     </main>
   );
@@ -106,4 +153,27 @@ function AnalyticsCard({
       </div>
     </Card>
   );
+}
+
+function mapHabitsToCalendarData(habits: Habit[]) {
+  const grouped: Record<string, number> = {};
+
+  habits.forEach((habit) => {
+    habit.activities.forEach((act) => {
+      const dateStr = new Date(act.date).toISOString().split("T")[0];
+      grouped[dateStr] = (grouped[dateStr] || 0) + 1;
+    });
+  });
+
+  const currentYear = new Date().getFullYear();
+  const lastDay = `${currentYear}-12-31`;
+  grouped[lastDay] = grouped[lastDay] || 0;
+
+  return Object.entries(grouped)
+    .map(([date, count]) => ({
+      date,
+      count,
+      level: Math.min(count, 4),
+    }))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }

--- a/lib/analytics-utils.ts
+++ b/lib/analytics-utils.ts
@@ -7,6 +7,8 @@ export interface AnalyticsStats {
   totalCheckIns: number;
   overallCompletionRate: number;
   longestStreak: number;
+  /** Consecutive days with at least one check-in across all habits */
+  globalStreak: number;
   checkInsThisWeek: number;
   bestHabit?: {
     id: string;
@@ -37,6 +39,10 @@ export function getAnalyticsStats(habits: Habit[]): AnalyticsStats {
     return streak > max ? streak : max;
   }, 0);
 
+  const globalStreak = calculateStreak(
+    habits.flatMap((habit) => habit.activities),
+  );
+
   let bestHabit: AnalyticsStats["bestHabit"];
   for (const habit of habits) {
     const rate = getHabitStats(habit).completionRate;
@@ -61,6 +67,7 @@ export function getAnalyticsStats(habits: Habit[]): AnalyticsStats {
     totalCheckIns,
     overallCompletionRate,
     longestStreak,
+    globalStreak,
     checkInsThisWeek,
     bestHabit,
   };

--- a/tests/analytics-utils.test.ts
+++ b/tests/analytics-utils.test.ts
@@ -42,6 +42,7 @@ describe("getAnalyticsStats", () => {
     expect(stats.totalHabits).toBe(2);
     expect(stats.totalCheckIns).toBe(3);
     expect(stats.longestStreak).toBe(2);
+    expect(stats.globalStreak).toBe(3);
     expect(stats.checkInsThisWeek).toBe(3);
     expect(stats.overallCompletionRate).toBe(15);
     expect(stats.bestHabit?.id).toBe("h1");


### PR DESCRIPTION
## Summary
- add global streak metric in analytics utils
- show refresh button and aggregated heatmap on analytics page
- handle empty analytics view
- update analytics tests for new metric

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9883b9208330a2642f4879d248df