### PR TITLE
Add calendar heatmap demo to landing page

### DIFF
--- a/app/(landing-page)/page.tsx
+++ b/app/(landing-page)/page.tsx
@@ -1,5 +1,6 @@
 import { FeatureGrid } from "../../components/landing/features";
 import { Hero } from "@/components/landing/hero";
+import { CalendarDemo } from "@/components/landing/calendar-demo";
 
 export default async function IndexPage() {
   return (
@@ -115,6 +116,8 @@ export default async function IndexPage() {
           },
         ]}
       />
+
+      <CalendarDemo />
     </>
   );
 }

--- a/components/landing/calendar-demo.tsx
+++ b/components/landing/calendar-demo.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ActivityCalendar } from "react-activity-calendar";
+import { useTheme } from "next-themes";
+import { useMemo } from "react";
+
+function generateDemoData() {
+  const days = 180;
+  const today = new Date();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const data = [] as { date: string; count: number; level: number }[];
+  for (let i = 0; i < days; i++) {
+    const date = new Date(today.getTime() - (days - i - 1) * dayMs);
+    const level = (i * 3) % 5;
+    data.push({ date: date.toISOString().split("T")[0], count: level, level });
+  }
+  return data;
+}
+
+export function CalendarDemo() {
+  const { resolvedTheme } = useTheme();
+  const data = useMemo(() => generateDemoData(), []);
+
+  return (
+    <section className="container space-y-6 py-8 md:py-12 lg:py-24">
+      <div className="mx-auto flex max-w-6xl flex-col items-center space-y-4 text-center">
+        <h2 className="text-3xl md:text-4xl font-semibold">
+          Calendar Heatmap Demo
+        </h2>
+        <p className="max-w-[85%] text-muted-foreground sm:text-lg">
+          Explore how your progress is visualized with a heatmap calendar.
+        </p>
+      </div>
+      <div className="flex justify-center">
+        <ActivityCalendar
+          data={data}
+          colorScheme={
+            resolvedTheme === "light" || resolvedTheme === "dark"
+              ? resolvedTheme
+              : undefined
+          }
+          theme={{
+            light: ["#e0e0e0", "#a3d8a3", "#78c78f", "#4dbb7f", "#26a65b"],
+            dark: [
+              "hsl(0, 0%, 22%)",
+              "#4dbb7f",
+              "#78c78f",
+              "#a3d8a3",
+              "#e0e0e0",
+            ],
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default CalendarDemo;


### PR DESCRIPTION
## Summary
- add `CalendarDemo` component showing a sample calendar heatmap
- include the demo section on the landing page

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6876d88c18708330a820d4c60a9aa270